### PR TITLE
Dashboard to see details of ranking refresh updates

### DIFF
--- a/lib/blueprints/ranking-blueprint/card-templates/ranking-refresh-viewer.json
+++ b/lib/blueprints/ranking-blueprint/card-templates/ranking-refresh-viewer.json
@@ -1,0 +1,171 @@
+{
+  "templateMeta": {
+    "name": "ranking-refresh-viewer",
+    "title": "View Ranking Refresh Updates",
+    "category": "system"
+  },
+  "hooks": {
+    "afterLeave": {
+      "actions": [
+        {
+          "type": "Action.StoreData"
+        }
+      ]
+    }
+  },
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "spacing": "none",
+      "items": [
+        {
+          "id": "key",
+          "type": "Input.ChoiceSet",
+          "title": "FSEC",
+          "clearable": true,
+          "choices": [
+            {
+              "title": "Care Home",
+              "value": "wmfs_careHome"
+            },
+            {
+              "title": "Converted Flat",
+              "value": "wmfs_convertedFlat"
+            },
+            {
+              "title": "Factory",
+              "value": "wmfs_factory"
+            },
+            {
+              "title": "Flat",
+              "value": "wmfs_flat"
+            },
+            {
+              "title": "Further Education",
+              "value": "wmfs_furtherEducation"
+            },
+            {
+              "title": "Hmo",
+              "value": "wmfs_hmo"
+            },
+            {
+              "title": "Hospital",
+              "value": "wmfs_hospital"
+            },
+            {
+              "title": "Hostel",
+              "value": "wmfs_hostel"
+            },
+            {
+              "title": "Hotel",
+              "value": "wmfs_hotel"
+            },
+            {
+              "title": "Licensed Premise",
+              "value": "wmfs_licensedPremise"
+            },
+            {
+              "title": "Office",
+              "value": "wmfs_office"
+            },
+            {
+              "title": "Other Sleeping",
+              "value": "wmfs_otherSleeping"
+            },
+            {
+              "title": "Other Workplace",
+              "value": "wmfs_otherWorkplace"
+            },
+            {
+              "title": "Public Building",
+              "value": "wmfs_publicBuilding"
+            },
+            {
+              "title": "Public Building Other",
+              "value": "wmfs_publicBuildingOther"
+            },
+            {
+              "title": "School",
+              "value": "wmfs_school"
+            },
+            {
+              "title": "Shop",
+              "value": "wmfs_shop"
+            }
+          ]
+        },
+        {
+          "type": "Container",
+          "spacing": "none",
+          "justifyContent": true,
+          "items": [
+            {
+              "type": "TextBlock",
+              "text": "{{ data.totalHits || 0 }} result{{ data.totalHits === 1 ? '' : 's' }}"
+            },
+            {
+              "type": "Action.ApiLookup",
+              "title": "Search",
+              "stateMachineName": "wmfs_rankingRefreshSearch_1_0",
+              "input": {
+                "page": "$.page",
+                "key": "$.key"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "spacing": "none",
+      "showWhen": "data.results && data.results.length",
+      "items": [
+        {
+          "id": "resultsList",
+          "type": "List",
+          "arrayPath": "data.results",
+          "templates": {
+            "badge": [
+              {
+                "showWhen": "item.status === 'STARTED'",
+                "text": "{{ item.status }}",
+                "colour": "warning"
+              },
+              {
+                "showWhen": "item.status === 'ENDED'",
+                "text": "{{ item.status }}",
+                "colour": "good"
+              },
+              {
+                "showWhen": "!['STARTED', 'ENDED'].includes(item.status)",
+                "text": "{{ item.status }}",
+                "colour": "standard"
+              }
+            ],
+            "label": "{{ item.key }}",
+            "sublabel": [
+              "{{ item.status === 'ENDED' ? `Duration: ${item.duration}` : 'Did not finish' }}",
+              "Last modified at {{ formatDate(item.modified, 'DD MMM YYYY HH:mm') }}"
+            ]
+          }
+        },
+        {
+          "type": "Pagination",
+          "page": "data.page",
+          "totalPages": "data.totalPages",
+          "endpoint": {
+            "stateMachineName": "wmfs_rankingRefreshSearch_1_0",
+            "input": {
+              "page": "$.page",
+              "key": "$.key"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.0"
+}

--- a/lib/blueprints/ranking-blueprint/card-templates/ranking-refresh-viewer.json
+++ b/lib/blueprints/ranking-blueprint/card-templates/ranking-refresh-viewer.json
@@ -20,6 +20,51 @@
       "spacing": "none",
       "items": [
         {
+          "type": "FactSet",
+          "facts": [
+            {
+              "title": "Average duration overall",
+              "value": "{{ data.avgDurationOverall }}"
+            }
+          ]
+        },
+        {
+          "type": "MarkupTable",
+          "title": "Average duration per FSEC",
+          "arrayPath": "data.avgDurationPerCategory",
+          "columns": [
+            {
+              "title": "FSEC",
+              "value": "{{ item.key }}"
+            },
+            {
+              "title": "Average",
+              "value": "{{ item.avg }}"
+            }
+          ]
+        },
+        {
+          "type": "MarkupTable",
+          "title": "Average duration per day (last 15 days)",
+          "arrayPath": "data.avgDurationPerDay",
+          "columns": [
+            {
+              "title": "Date",
+              "value": "{{ formatDate(item.date, 'DD MMM YYYY') }}"
+            },
+            {
+              "title": "Average",
+              "value": "{{ item.avg }}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "Container",
+      "spacing": "none",
+      "items": [
+        {
           "id": "key",
           "type": "Input.ChoiceSet",
           "title": "FSEC",

--- a/lib/blueprints/ranking-blueprint/functions/ranking-refresh-get-stats.js
+++ b/lib/blueprints/ranking-blueprint/functions/ranking-refresh-get-stats.js
@@ -1,0 +1,38 @@
+const { startCase } = require('lodash')
+
+const sql = {
+  avgDurationOverall: 'select avg(age(_modified, _created)) from wmfs.ranking_refresh_status where status = \'ENDED\';',
+  avgDurationPerCategory: 'select key, avg(age(_modified, _created)) from wmfs.ranking_refresh_status where status = \'ENDED\' group by key order by key asc;',
+  avgDurationPerDay: 'select date_trunc(\'day\', _modified) as date, AVG(AGE(_modified, _created)) from wmfs.ranking_refresh_status group by date_trunc(\'day\', _modified) order by date_trunc(\'day\', _modified) desc limit 15;'
+}
+
+module.exports = function rankingRefreshGetStats () {
+  return async function (env) {
+    const { client } = env.bootedServices.storage
+
+    const { rows: avgDurationOverall } = await client.query(sql.avgDurationOverall)
+    const { rows: avgDurationPerCategory } = await client.query(sql.avgDurationPerCategory)
+    const { rows: avgDurationPerDay } = await client.query(sql.avgDurationPerDay)
+
+    const transformAvg = avg => {
+      const properties = ['years', 'months', 'days', 'hours', 'minutes', 'seconds']
+
+      return Object.entries(avg)
+        .filter(([k]) => properties.includes(k))
+        .map(([k, v]) => `${v} ${k}`)
+        .join(' ')
+    }
+
+    const transform = r => {
+      r.avg = transformAvg(r.avg)
+      if (r.key) r.key = startCase(r.key.split('wmfs_')[1])
+      return r
+    }
+
+    return {
+      avgDurationOverall: transformAvg(avgDurationOverall[0].avg),
+      avgDurationPerCategory: avgDurationPerCategory.map(transform),
+      avgDurationPerDay: avgDurationPerDay.map(transform)
+    }
+  }
+}

--- a/lib/blueprints/ranking-blueprint/functions/ranking-refresh-search.js
+++ b/lib/blueprints/ranking-blueprint/functions/ranking-refresh-search.js
@@ -1,0 +1,37 @@
+const moment = require('moment')
+
+module.exports = function rankingRefreshSearch () {
+  return async function (env, event) {
+    const model = env.bootedServices.storage.models.wmfs_rankingRefreshStatus
+
+    const key = event.key ? event.key.trim() : null
+
+    const limit = 10
+    const page = event.page || 1
+    const offset = (page - 1) * limit
+
+    const where = {}
+
+    if (key && key !== '$ALL') where.key = { equals: key }
+
+    const results = await model.find({ where, offset, limit, orderBy: ['-modified'] })
+    const totalHits = await model.findCount({ where })
+    const totalPages = Math.ceil(totalHits / limit)
+
+    const transform = x => {
+      if (x.status === 'ENDED') {
+        const start = moment(x.created)
+        const end = moment(x.modified)
+        x.duration = moment.duration(end.diff(start)).humanize()
+      }
+      return x
+    }
+
+    return {
+      page,
+      totalPages,
+      results: results.map(transform),
+      totalHits
+    }
+  }
+}

--- a/lib/blueprints/ranking-blueprint/state-machines/ranking-refresh-search.json
+++ b/lib/blueprints/ranking-blueprint/state-machines/ranking-refresh-search.json
@@ -1,0 +1,25 @@
+{
+  "Comment": "Search Ranking Refresh",
+  "name": "Search Ranking Refresh",
+  "Version": "1.0",
+  "version": "1.0",
+  "categories": [
+    "system"
+  ],
+  "StartAt": "Search",
+  "States": {
+    "Search": {
+      "Type": "Task",
+      "Resource": "function:wmfs_rankingRefreshSearch",
+      "End": true
+    }
+  },
+  "restrictions": [
+    {
+      "roleId": "system_system",
+      "allows": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/lib/blueprints/ranking-blueprint/state-machines/ranking-refresh-viewer.json
+++ b/lib/blueprints/ranking-blueprint/state-machines/ranking-refresh-viewer.json
@@ -10,13 +10,20 @@
     "user"
   ],
   "instigatorGroup": "app",
-  "StartAt": "AwaitingHumanInput",
+  "StartAt": "GetStats",
   "States": {
+    "GetStats": {
+      "Type": "Task",
+      "Resource": "function:wmfs_rankingRefreshGetStats",
+      "ResultPath": "$",
+      "Next": "AwaitingHumanInput"
+    },
     "AwaitingHumanInput": {
       "Type": "Task",
       "Resource": "module:awaitingHumanInput",
       "ResourceConfig": {
-        "uiName": "wmfs_rankingRefreshViewer"
+        "uiName": "wmfs_rankingRefreshViewer",
+        "dataPath": "$"
       },
       "End": true
     }

--- a/lib/blueprints/ranking-blueprint/state-machines/ranking-refresh-viewer.json
+++ b/lib/blueprints/ranking-blueprint/state-machines/ranking-refresh-viewer.json
@@ -1,0 +1,32 @@
+{
+  "Comment": "View Ranking Refresh Updates",
+  "name": "View Ranking Refresh Updates",
+  "Version": "1.0",
+  "version": "1.0",
+  "categories": [
+    "system"
+  ],
+  "instigators": [
+    "user"
+  ],
+  "instigatorGroup": "app",
+  "StartAt": "AwaitingHumanInput",
+  "States": {
+    "AwaitingHumanInput": {
+      "Type": "Task",
+      "Resource": "module:awaitingHumanInput",
+      "ResourceConfig": {
+        "uiName": "wmfs_rankingRefreshViewer"
+      },
+      "End": true
+    }
+  },
+  "restrictions": [
+    {
+      "roleId": "system_system",
+      "allows": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "@semantic-release/exec": "6.0.2",
     "@wmfs/hl-pg-client": "1.28.0",
     "@wmfs/tymly": "1.220.0",
-    "@wmfs/tymly-pg-plugin": "1.256.0"
+    "@wmfs/tymly-pg-plugin": "1.256.0",
+    "@wmfs/tymly-test-helpers": "1.11.0"
   },
   "scripts": {
     "lint": "standard",

--- a/test/ranking-spec.js
+++ b/test/ranking-spec.js
@@ -52,7 +52,8 @@ describe('Tests the Ranking State Resource', function () {
         {
           pluginPaths: [
             path.resolve(__dirname, './..'),
-            require.resolve('@wmfs/tymly-pg-plugin')
+            require.resolve('@wmfs/tymly-pg-plugin'),
+            require.resolve('@wmfs/tymly-test-helpers/plugins/mock-users-plugin')
           ],
           blueprintPaths: [
             path.resolve(__dirname, './fixtures/blueprint'),


### PR DESCRIPTION
Dashboard is restricted to `system_system` role.

Find out average duration of refreshes
Find out average duration per category
Find out average duration per date (last 15 days)
Search all ranking refreshes