### PR TITLE
Resolve issue with semantic-release changelog notes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,7 +12,56 @@
     "@semantic-release/git"
   ],
   "generateNotes": {
-    "preset": "angular"
+    "preset": "conventionalcommits",
+    "presetConfig": {
+      "types": [
+        {
+          "breaking": true,
+          "type": "feat!",
+          "section": "BREAKING"
+        },
+        {
+          "type": "feat",
+          "section": "New Feature(s) :rocket:"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fix(es) :bug:"
+        },
+        {
+          "type": "docs",
+          "section": "Documentation Changes :memo:"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactor :recycle:"
+        },
+        {
+          "type": "test",
+          "section": "Tests :alembic:"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvement(s) :zap:"
+        },
+        {
+          "type": "build",
+          "section": "Build system dependencies :hammer:"
+        },
+        {
+          "type": "chore",
+          "section": "Chores :pencil2:"
+        },
+        {
+          "type": "ci",
+          "section": "CICD Configuration Changes :construction_worker:"
+        },
+        {
+          "type": "style",
+          "section": "Code Styling :art:"
+        }
+      ]
+    }
   },
   "prepare": [
     {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "semantic-release": "24.2.0",
     "standard": "17.1.2",
     "@semantic-release/changelog": "6.0.3",
+    "@semantic-release/release-notes-generator": "14.0.1",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/exec": "6.0.3",
     "@wmfs/hl-pg-client": "1.34.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "4.5.0",
     "codecov": "3.8.3",
-    "conventional-changelog-metahub": "4.0.1",
+    "conventional-changelog-conventionalcommits": "8.0.0"
     "cz-conventional-changelog": "3.3.0",
     "mocha": "11.0.1",
     "nyc": "17.1.0",


### PR DESCRIPTION
Hello former workplace associates.

For some reason `angular` preset no longer seems to be including certain commit types when writing to changelog.md, in particular commits with the type & scope of `build(deps):`

Had to change preset for `generateNotes` to `conventionalcommits`, then add `presetConfig` for each commit type.  That is because `conventional-changelog-conventionalcommits` by default [hides](https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types) a number of commit types.  For some reason adding it `presetConfig` when preset is set to `angular` didn't fix issue.

Please note I have added 'fun' emojis to various sections within presetConfig.  Feel free to remove those if you don't want them.

Added [conventional-changelog-conventionalcommits](https://github.com/conventional-changelog/conventional-changelog-config-spec) and [@semantic-release/release-notes-generator](https://github.com/semantic-release/release-notes-generator) to devDependencies.